### PR TITLE
bugfixes for camera system + block properties

### DIFF
--- a/src/main/java/net/mokai/quicksandrehydrated/QuicksandRehydrated.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/QuicksandRehydrated.java
@@ -3,7 +3,6 @@ package net.mokai.quicksandrehydrated;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.Direction.Axis;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
@@ -11,6 +10,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
@@ -27,7 +27,7 @@ import net.mokai.quicksandrehydrated.networking.ModMessages;
 import net.mokai.quicksandrehydrated.registry.*;
 import net.mokai.quicksandrehydrated.screen.MixerScreen;
 import net.mokai.quicksandrehydrated.screen.ModMenuTypes;
-import net.mokai.quicksandrehydrated.util.Tristate;
+import net.mokai.quicksandrehydrated.util.CameraBoxDimensions;
 import net.mokai.quicksandrehydrated.worldgen.ModRegion;
 import net.mokai.quicksandrehydrated.worldgen.ModSurfaceRuleData;
 import net.mokai.quicksandrehydrated.worldgen.placement.ModPlacementModifierTypes;
@@ -94,40 +94,50 @@ public class QuicksandRehydrated {
         }
     }
 
-    private static Tristate entityCanBreatheWithOffset(LivingEntity entity, double upwardsYOffset) {
-        // Screen goes dark when the eye position is ~0.05 units above the quicksand block, so we adjust drowning behavior to match
-        // Found this value by experimentation and logging, couldn't actually find the code that handles the screen going dark, so this is an educated guess
-        // If anyone gets a better measurement or finds a definitive source for this value please update it
-        double cameraYOffset = -0.05;
-        Vec3 position = entity.getEyePosition().relative(Direction.UP, upwardsYOffset + cameraYOffset);
-        BlockPos blockPosition = BlockPos.containing(position);
-        BlockState blockState = entity.level().getBlockState(blockPosition);
+
+    // Used to check whether the *first-person camera* is inside a block of quicksand
+    // We use this as the main mechanism to determine if we're drowning or not
+    private static boolean boxOverlapsQuicksandBlock(Level level, AABB box) {
+        BlockPos minXYZ = BlockPos.containing(box.minX, box.minY, box.minZ);
+        BlockPos maxXYZ = BlockPos.containing(box.maxX, box.maxY, box.maxZ);
+        for (BlockPos blockPos: BlockPos.betweenClosed(minXYZ, maxXYZ)) {
+            BlockState blockState = level.getBlockState(blockPos);
+            // Previously also had an "instanceof QuicksandBase" check, but I'm not sure if we need that
+            if (!blockState.isAir() && blockState.is(QUICKSAND_DROWNABLE)) {
+                // Intentionally use the visual bounds of the block, rather than the colission mark.
+                // Assumes the quicksand shape is some kindof cube / rectangular prism
+                AABB boundingBox = blockState.getShape(level, blockPos).bounds().move(blockPos);
+                if (boundingBox.intersects(box)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+    // Used to check for "bonus" air such as the snorkel and reed
+    private static boolean hasBonusAirAt(LivingEntity entity, double yOffset) {
+        var level = entity.level();
+        Vec3 position = entity.getEyePosition().relative(Direction.UP, yOffset);
+        BlockPos blockPos = BlockPos.containing(position);
+        BlockState blockState = level.getBlockState(blockPos);
         if (blockState.isAir()) {
-            return Tristate.YES;
+            return true;
         }
         // Previously also had an "instanceof QuicksandBase" check, but I'm not sure if we need that
         if (blockState.is(QUICKSAND_DROWNABLE)) {
-            // Intentionally use the visual height of the block, rather than the colission mark,
-            // since drowning should start when the (first-person) camera visually goes under.
-            double quicksandVisualHeight = blockState.getShape(entity.level(), blockPosition).max(Axis.Y);
-            // System.out.printf("Quicksand Height: %f %f\n", position.y, quicksandVisualHeight);
-            return position.y < blockPosition.getY() + quicksandVisualHeight ? Tristate.NO : Tristate.YES;
+            // Assumes the quicksand is a box
+            AABB boundingBox = blockState.getShape(level, blockPos).bounds().move(blockPos);
+            return !boundingBox.contains(position);
         }
         FluidState fluidState = blockState.getFluidState();
         if (fluidState.getFluidType().canDrownIn(entity)) {
-            // Trying to match minecraft's behavior, but there seems to be a mismatch for water height
-            // Apparently need to add a small amount to the fluid's height to compensate?
-            // Notably, minecraft says you start drowning *before* the camera actually goes under.
-            // Measured this out while testing with Water (both source blocks and flowing water at all heights)
-            // Haven't tested if this impacts other fluids
-            // If anyone gets a better measurement or finds a definitive source for this value please update it
-            double liquidHeightOffset = 0.05;
-            // System.out.printf("Fluid Height: %f %f\n", position.y - blockPosition.getY(), fluidState.getOwnHeight());
-            return (position.y < blockPosition.getY() + fluidState.getOwnHeight() + liquidHeightOffset) ? Tristate.NO : Tristate.YES;
+            // Can breathe if we're above the surface of the fluid, otherwise not
+            return position.y > blockPos.getY() + fluidState.getOwnHeight();
         }
-        // Some other situation, assume that minecraft's built in drowning and any other mods will handle it
-        // TODO: Non-solid "breathable" blocks like signs will hit this point, should work on handling this in case the snorkel is sitting in one
-        return Tristate.MAYBE;
+        // For everything else, we can breathe in non-solid blocks like signs
+        return !blockState.isSolid();
     }
 
     private static boolean entityIsHoldingReed(LivingEntity entity) {
@@ -164,35 +174,26 @@ public class QuicksandRehydrated {
             double reedHeight = 2;
             double snorkelHeight = 1.5; // SET TO BE CONFIGURABLE
 
-            Tristate canBreathNormally = entityCanBreatheWithOffset(entity, 0);
-            boolean canBreatheThroughReed = entityIsHoldingReed(entity) && entityCanBreatheWithOffset(entity, reedHeight) == Tristate.YES;
-            boolean canBreatheThroughSnokel = entityIsWearingSnorkel(entity) && entityCanBreatheWithOffset(entity, snorkelHeight) == Tristate.YES;
+            boolean canBreatheThroughReed = entityIsHoldingReed(entity) && hasBonusAirAt(entity, reedHeight);
+            boolean canBreatheThroughSnokel = entityIsWearingSnorkel(entity) && hasBonusAirAt(entity, snorkelHeight);
 
-            // if (entity instanceof Player) {
-            //     double eyesAboveBlock = entity.getEyeY() - Math.floor(entity.getEyeY());
-            //     System.out.printf(
-            //         "onLivingBreatheEvent: event.canBreathe: %b, event.canRefillAir: %b, canBreathNormally: %s, canBreatheThroughReed: %b, canBreatheThroughSnokel: %b, eyesAboveBlock: %f\n",
-            //         event.canBreathe(),
-            //         event.canRefillAir(),
-            //         canBreathNormally.name(),
-            //         canBreatheThroughReed,
-            //         canBreatheThroughSnokel,
-            //         eyesAboveBlock
-            //     );
-            // }
-
-            if (canBreatheThroughReed || canBreatheThroughSnokel || canBreathNormally == Tristate.YES) {
+            if (canBreatheThroughReed || canBreatheThroughSnokel) {
                 // If we're certain we have a source of air, we can breathe
                 event.setCanBreathe(true);
                 event.setCanRefillAir(true);
-            } else if (canBreathNormally == Tristate.NO) {
-                // We're definitely suffocating, mrrrrhf~
-                event.setCanBreathe(false);
-                event.setCanRefillAir(false);
+            } else {
+                double w = CameraBoxDimensions.FULL_WIDTH;
+                double h = CameraBoxDimensions.FULL_HEIGHT;
+                AABB cameraBox = AABB.ofSize(entity.getEyePosition(), w, h, w);
+                if (boxOverlapsQuicksandBlock(entity.level(), cameraBox)) {
+                    // We're definitely suffocating, mrrrrhf~
+                    event.setCanBreathe(false);
+                    event.setCanRefillAir(false);
+                }
             }
 
-            // canBreathNormally is MAYBE
-            // Got a situation we're not sure about, don't modify the event at all and assume something else handles it
+            // We're in some other situation. Don't modify the event at all and assume something else handles it
+            // (e.g. drowning in water is already handled by the game)
         }
         
         @SubscribeEvent

--- a/src/main/java/net/mokai/quicksandrehydrated/block/quicksands/core/FlowingQuicksandBase.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/block/quicksands/core/FlowingQuicksandBase.java
@@ -39,7 +39,7 @@ public class FlowingQuicksandBase extends QuicksandBase implements QuicksandInte
         if (state == null) return 0.0;
         if (state.getBlock() != this) return 0.0;
         if (!state.hasProperty(LEVEL)) return 0.0;
-        return (1.0 - (state.getValue(LEVEL) / 4.0)) - QSBehavior.getOffset();
+        return (1.0 - (state.getValue(LEVEL) / 4.0)) + QSBehavior.getOffset();
     }
 
     public double getCoverageFraction(BlockState state) {
@@ -97,6 +97,9 @@ public class FlowingQuicksandBase extends QuicksandBase implements QuicksandInte
             Block.box(0, 0, 0, 16, 16, 16)
     };
 
+    // Yeah I'm a bit surprised at this one myself tbh
+    protected static final float[] SHADE_BRIGHTNESS_BY_LEVEL = new float[]{1.0f, 1.0f, 1.0f, 1.0f, 0.2f};
+
     @Override
     public VoxelShape getOcclusionShape(BlockState pState, BlockGetter pLevel, BlockPos pPos) {
         return SHAPE_BY_LEVEL[pState.getValue(LEVEL)];
@@ -118,8 +121,16 @@ public class FlowingQuicksandBase extends QuicksandBase implements QuicksandInte
     }
 
     @Override
-    public VoxelShape getVisualShape(BlockState pState, BlockGetter pReader, BlockPos pPos, CollisionContext pContext) {
-        return SHAPE_BY_LEVEL[pState.getValue(LEVEL)];
+    public float getShadeBrightness(BlockState pState, BlockGetter pReader, BlockPos pPos) {
+        return SHADE_BRIGHTNESS_BY_LEVEL[pState.getValue(LEVEL)];
+    }
+
+    /**
+     * QuicksandBase culls internal faces, but since we have blocks of varying heights, if we did that we'd have holes.
+     * Maybe there's something smart we can do here but I can't think of it right now.
+     */
+    public boolean skipRendering(BlockState blockStateA, BlockState blockStateB, Direction direction) {
+        return false;
     }
 
     @Override

--- a/src/main/java/net/mokai/quicksandrehydrated/block/quicksands/core/FlowingQuicksandBase.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/block/quicksands/core/FlowingQuicksandBase.java
@@ -125,14 +125,6 @@ public class FlowingQuicksandBase extends QuicksandBase implements QuicksandInte
         return SHADE_BRIGHTNESS_BY_LEVEL[pState.getValue(LEVEL)];
     }
 
-    /**
-     * QuicksandBase culls internal faces, but since we have blocks of varying heights, if we did that we'd have holes.
-     * Maybe there's something smart we can do here but I can't think of it right now.
-     */
-    public boolean skipRendering(BlockState blockStateA, BlockState blockStateB, Direction direction) {
-        return false;
-    }
-
     @Override
     public boolean canBeReplaced(BlockState pState, BlockPlaceContext pUseContext) {
         int current_level = pState.getValue(LEVEL);

--- a/src/main/java/net/mokai/quicksandrehydrated/block/quicksands/core/QuicksandBase.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/block/quicksands/core/QuicksandBase.java
@@ -595,15 +595,6 @@ public class QuicksandBase extends Block implements QuicksandInterface {
         return 0.2F;
     }
 
-    /**
-     * Stolen from net.minecraft.world.level.block.HalfTransparentBlock
-     * Avoid rendering faces between two blocks of quicksand
-     * Normally these get culled, but getVisualShape being empty stops that from happening, so we have to do it ourselves
-     */
-    public boolean skipRendering(BlockState someOtherBlockState, BlockState blockState, Direction direction) {
-        return blockState.is(this) ? true : super.skipRendering(someOtherBlockState, blockState, direction);
-    }
-
     public boolean checkDrownable(BlockState pState) {
         return pState.getTags().toList().contains(QUICKSAND_DROWNABLE)
             || pState.getFluidState().getTags().toList().contains(QUICKSAND_DROWNABLE_FLUID);

--- a/src/main/java/net/mokai/quicksandrehydrated/block/quicksands/core/QuicksandBase.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/block/quicksands/core/QuicksandBase.java
@@ -1,6 +1,7 @@
 package net.mokai.quicksandrehydrated.block.quicksands.core;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -576,11 +577,35 @@ public class QuicksandBase extends Block implements QuicksandInterface {
         return Shapes.block();
     }
 
-    public boolean checkDrownable(BlockState pState) {
-        return pState.getTags().toList().contains(QUICKSAND_DROWNABLE)
-                || pState.getFluidState().getTags().toList().contains(QUICKSAND_DROWNABLE_FLUID);
+    /**
+     * Ensures the camera can pass through the block, which means third person view works properly when the player is submerged.
+     * Declared final because I don't want people to accidentally override this without reading this comment lol.
+     */
+    @Override
+    final public VoxelShape getVisualShape(BlockState pState, BlockGetter pReader, BlockPos pPos, CollisionContext pContext) {
+        return Shapes.empty();
     }
 
+    /**
+     * Need this to make sure quicksand blocks actually cast shadows + block light.
+     * Value taken from the vanilla Mud block.
+     */
+    @Override
+    public float getShadeBrightness(BlockState p_221552_, BlockGetter p_221553_, BlockPos p_221554_) {
+        return 0.2F;
+    }
 
+    /**
+     * Stolen from net.minecraft.world.level.block.HalfTransparentBlock
+     * Avoid rendering faces between two blocks of quicksand
+     * Normally these get culled, but getVisualShape being empty stops that from happening, so we have to do it ourselves
+     */
+    public boolean skipRendering(BlockState someOtherBlockState, BlockState blockState, Direction direction) {
+        return blockState.is(this) ? true : super.skipRendering(someOtherBlockState, blockState, direction);
+    }
 
+    public boolean checkDrownable(BlockState pState) {
+        return pState.getTags().toList().contains(QUICKSAND_DROWNABLE)
+            || pState.getFluidState().getTags().toList().contains(QUICKSAND_DROWNABLE_FLUID);
+    }
 }

--- a/src/main/java/net/mokai/quicksandrehydrated/mixins/ScreenEffectRendererMixin.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/mixins/ScreenEffectRendererMixin.java
@@ -1,0 +1,61 @@
+package net.mokai.quicksandrehydrated.mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import javax.annotation.Nullable;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ScreenEffectRenderer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.mokai.quicksandrehydrated.util.CameraBoxDimensions;
+import org.apache.commons.lang3.tuple.Pair;
+
+
+@OnlyIn(Dist.CLIENT)
+@Mixin(ScreenEffectRenderer.class)
+public abstract class ScreenEffectRendererMixin {
+
+    @Inject(method = "renderScreenEffect", at = @At("HEAD"))
+    private static void renderScreenEffectHook(Minecraft minecraft, PoseStack poseStack, CallbackInfo ci) {
+        Player player = minecraft.player;
+        if (player != null && !player.noPhysics) {
+            // Can hook in here for additional screen overlay hijinks.
+            // Maybe a partial screen coverage after the player has resurfaced?
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Nullable
+    private static Pair<BlockState, BlockPos> getOverlayBlock(Player player) {
+        // Original implementation uses a MutableBlockPos, possibly for performance reasons?
+        BlockPos.MutableBlockPos mutableBlockPos = new BlockPos.MutableBlockPos();
+        double w = CameraBoxDimensions.HALF_WIDTH;
+        double h = CameraBoxDimensions.HALF_HEIGHT;
+        // Imagine a small box where the player's eye is.
+        // We check each corner of this box to see if it's inside a block. If it is, we obscure the screen.
+        for (int i = 0; i < 8; ++i) {
+            // Originally, the x and z axis were using player.getBbWidth() * 0.8 which is way larger than we wanted lol
+            double x = ((i & 1) == 0 ? -w : w) + player.getX();
+            double y = ((i & 2) == 0 ? -h : h) + player.getEyeY();
+            double z = ((i & 4) == 0 ? -w : w) + player.getZ();
+            mutableBlockPos.set(x, y, z);
+            BlockState blockState = player.level().getBlockState(mutableBlockPos);
+            if (blockState.getRenderShape() != RenderShape.INVISIBLE && blockState.isViewBlocking(player.level(), mutableBlockPos)) {
+                // Need to handle view blocking blocks which aren't a full block (vanilla doesn't have any of these)
+                // Currently only works if they're some form of cube or rectangular prism
+                if (blockState.getShape(player.level(), mutableBlockPos).bounds().move(mutableBlockPos).contains(x, y, z)) {
+                    return Pair.of(blockState, mutableBlockPos.immutable());
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/net/mokai/quicksandrehydrated/mixins/ScreenEffectRendererMixin.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/mixins/ScreenEffectRendererMixin.java
@@ -13,6 +13,9 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.shapes.BooleanOp;
+import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.mokai.quicksandrehydrated.util.CameraBoxDimensions;
@@ -35,27 +38,52 @@ public abstract class ScreenEffectRendererMixin {
     @SuppressWarnings("unused")
     @Nullable
     private static Pair<BlockState, BlockPos> getOverlayBlock(Player player) {
-        // Original implementation uses a MutableBlockPos, possibly for performance reasons?
-        BlockPos.MutableBlockPos mutableBlockPos = new BlockPos.MutableBlockPos();
-        double w = CameraBoxDimensions.HALF_WIDTH;
-        double h = CameraBoxDimensions.HALF_HEIGHT;
-        // Imagine a small box where the player's eye is.
-        // We check each corner of this box to see if it's inside a block. If it is, we obscure the screen.
-        for (int i = 0; i < 8; ++i) {
-            // Originally, the x and z axis were using player.getBbWidth() * 0.8 which is way larger than we wanted lol
-            double x = ((i & 1) == 0 ? -w : w) + player.getX();
-            double y = ((i & 2) == 0 ? -h : h) + player.getEyeY();
-            double z = ((i & 4) == 0 ? -w : w) + player.getZ();
-            mutableBlockPos.set(x, y, z);
-            BlockState blockState = player.level().getBlockState(mutableBlockPos);
-            if (blockState.getRenderShape() != RenderShape.INVISIBLE && blockState.isViewBlocking(player.level(), mutableBlockPos)) {
-                // Need to handle view blocking blocks which aren't a full block (vanilla doesn't have any of these)
-                // Currently only works if they're some form of cube or rectangular prism
-                if (blockState.getShape(player.level(), mutableBlockPos).bounds().move(mutableBlockPos).contains(x, y, z)) {
-                    return Pair.of(blockState, mutableBlockPos.immutable());
-                }
-            }
+        // Unaltered hitbox for suffocation. It's larger so we check this one first
+        // Dimensions + condition check taken from Entity.java:isInWall
+        var suffocatingIn = getOverlayBlockFor(player, player.getBbWidth() * 0.8d, 1.0e-6d, (blockState, blockPos, aabb) ->
+            !blockState.isAir()
+            && blockState.isSuffocating(player.level(), blockPos)
+            && (
+                Shapes.joinIsNotEmpty(
+                    blockState.getCollisionShape(player.level(), blockPos).move(
+                        (double)blockPos.getX(),
+                        (double)blockPos.getY(),
+                        (double)blockPos.getZ()
+                    ),
+                    Shapes.create(aabb),
+                    BooleanOp.AND
+                )
+            )
+        );
+        if (suffocatingIn != null) {
+            return suffocatingIn;
+        }
+        // Smaller, customised hitbox for drowning, check it second
+        var drowningIn = getOverlayBlockFor(player, CameraBoxDimensions.FULL_WIDTH, CameraBoxDimensions.FULL_HEIGHT, (blockState, blockPos, aabb) ->
+            blockState.getRenderShape() != RenderShape.INVISIBLE
+            && blockState.isViewBlocking(player.level(), blockPos)
+            // Need to handle view blocking blocks which aren't a full block (vanilla doesn't have any of these)
+            // Currently only works if they're some form of cube or rectangular prism
+            && blockState.getShape(player.level(), blockPos).bounds().move(blockPos).intersects(aabb)
+        );
+        if (drowningIn != null) {
+            return drowningIn;
         }
         return null;
+    }
+
+    @Nullable
+    private static Pair<BlockState, BlockPos> getOverlayBlockFor(Player player, double w, double h, Predicate condition) {
+        AABB aabb = AABB.ofSize(player.getEyePosition(), w, h, w);
+        return BlockPos
+            .betweenClosedStream(aabb)
+            .map(blockPos -> Pair.of(player.level().getBlockState(blockPos), blockPos))
+            .filter(pair -> condition.test(pair.getLeft(), pair.getRight(), aabb))
+            .findFirst()
+            .orElse(null);
+    }
+
+    static interface Predicate {
+        boolean test(BlockState blockState, BlockPos blockPos, AABB aabb);
     }
 }

--- a/src/main/java/net/mokai/quicksandrehydrated/mixins/SlowdownMixin.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/mixins/SlowdownMixin.java
@@ -134,7 +134,7 @@ public abstract class SlowdownMixin implements entityQuicksandVar {
         // Adjust only the surface block to be shorter
         BlockState blockAbove = pEntity.level().getBlockState(pPos.above());
         boolean isSurface = blockAbove.isAir() || !(blockAbove.getBlock() instanceof QuicksandBase);
-        double quicksandHeight = isSurface ? 1 - quicksand.getQuicksandBehavior().getOffset() : 1;
+        double quicksandHeight = isSurface ? 1 - quicksand.getOffset(pState) : 1;
 
         AABB blockBoundingBox = new AABB(pPos).setMaxY(pPos.getY() + quicksandHeight);
         AABB entityBoundingBox = pEntity.getBoundingBox();

--- a/src/main/java/net/mokai/quicksandrehydrated/registry/QuicksandRegistry.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/registry/QuicksandRegistry.java
@@ -59,7 +59,7 @@ public class QuicksandRegistry {
     private final static BlockBehaviour.Properties woolBlockBehavior = copyBlockProps(Blocks.WHITE_WOOL).friction(1.0F).strength(2.5F);
 
     private static BlockBehaviour.Properties copyBlockProps(Block block) {
-        return BlockBehaviour.Properties.copy(Blocks.SAND).noCollission().forceSolidOn().isViewBlocking((A, B, C) -> true);
+        return BlockBehaviour.Properties.copy(block).noCollission().forceSolidOn().isViewBlocking((A, B, C) -> true);
     }
 
     // --------------------------------- Quicksand properties -----------------------------

--- a/src/main/java/net/mokai/quicksandrehydrated/registry/QuicksandRegistry.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/registry/QuicksandRegistry.java
@@ -52,18 +52,15 @@ public class QuicksandRegistry {
      */
     // --------------------------------- Block properties -----------------------------
 
+    private final static BlockBehaviour.Properties baseBlockBehavior = copyBlockProps(Blocks.SAND).requiresCorrectToolForDrops();
+    private final static BlockBehaviour.Properties muddyBlockBehavior = copyBlockProps(Blocks.MUD).requiresCorrectToolForDrops();
+    private final static BlockBehaviour.Properties baseFlowingBlockBehavior = copyBlockProps(Blocks.SAND).requiresCorrectToolForDrops();
+    private final static BlockBehaviour.Properties slimeBlockBehavior = copyBlockProps(Blocks.SLIME_BLOCK).friction(1.0F).strength(2.5F);
+    private final static BlockBehaviour.Properties woolBlockBehavior = copyBlockProps(Blocks.WHITE_WOOL).friction(1.0F).strength(2.5F);
 
-    private final static BlockBehaviour.Properties baseBlockBehavior = BlockBehaviour.Properties.copy(Blocks.SAND).noCollission().requiresCorrectToolForDrops()
-            .noOcclusion().isViewBlocking((A, B, C) -> true).forceSolidOn();
-    private final static BlockBehaviour.Properties muddyBlockBehavior = BlockBehaviour.Properties.copy(Blocks.MUD).noCollission().requiresCorrectToolForDrops()
-            .noOcclusion().isViewBlocking((A, B, C) -> true).forceSolidOn();
-    private final static BlockBehaviour.Properties baseFlowingBlockBehavior = BlockBehaviour.Properties.copy(Blocks.SAND).noCollission().requiresCorrectToolForDrops()
-            .noOcclusion().isViewBlocking((A, B, C) -> A.getValue(FlowingQuicksandBase.LEVEL) >= 4).forceSolidOn();
-    private final static BlockBehaviour.Properties slimeBlockBehavior = BlockBehaviour.Properties.copy(Blocks.SLIME_BLOCK).noCollission()
-            .noOcclusion().isViewBlocking((A, B, C) -> true).friction(1.0F).strength(2.5F).forceSolidOn();
-    private final static BlockBehaviour.Properties woolBlockBehavior = BlockBehaviour.Properties.copy(Blocks.WHITE_WOOL).noCollission()
-            .noOcclusion().isViewBlocking((A, B, C) -> true).friction(1.0F).strength(2.5F).forceSolidOn();
-
+    private static BlockBehaviour.Properties copyBlockProps(Block block) {
+        return BlockBehaviour.Properties.copy(Blocks.SAND).noCollission().forceSolidOn().isViewBlocking((A, B, C) -> true);
+    }
 
     // --------------------------------- Quicksand properties -----------------------------
 

--- a/src/main/java/net/mokai/quicksandrehydrated/util/CameraBoxDimensions.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/util/CameraBoxDimensions.java
@@ -1,0 +1,12 @@
+package net.mokai.quicksandrehydrated.util;
+
+// Dimensions of a small rectangle around the player's viewport
+// We use this for both screen cover effects and drowning
+// Putting the constants in this file since both of those systems need to be in sync
+public class CameraBoxDimensions {
+	public static double HALF_WIDTH = 0.09;
+	public static double HALF_HEIGHT = 0.05;
+
+	public static double FULL_WIDTH = HALF_WIDTH * 2;
+	public static double FULL_HEIGHT = HALF_HEIGHT * 2;
+}

--- a/src/main/java/net/mokai/quicksandrehydrated/util/Tristate.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/util/Tristate.java
@@ -1,7 +1,0 @@
-package net.mokai.quicksandrehydrated.util;
-
-public enum Tristate {
-    NO,
-    YES,
-    MAYBE
-};

--- a/src/main/resources/data/qsrehydrated/tags/blocks/quicksand_ao_override.json
+++ b/src/main/resources/data/qsrehydrated/tags/blocks/quicksand_ao_override.json
@@ -5,6 +5,7 @@
     "qsrehydrated:thin_mud",
     "qsrehydrated:shallow_mud",
     "qsrehydrated:deep_mud",
-    "qsrehydrated:bottomless_mud"
+    "qsrehydrated:bottomless_mud",
+    "qsrehydrated:tidal_mud"
   ]
 }

--- a/src/main/resources/qsrehydrated.mixins.json
+++ b/src/main/resources/qsrehydrated.mixins.json
@@ -9,7 +9,8 @@
     "FallingBlockEntityMixin",
     "CanOccludeMixin",
     "SlowdownMixin",
-    "PlayerRendererMixin"
+    "PlayerRendererMixin",
+    "ScreenEffectRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Change List

- Added `ScreenEffectRendererMixin` which handles the screen coverage effect. You can now get much closer to a quicksand block (from the side) before the screen cover happens. Drowning is now properly synchronised with screen cover, so you don't get one but not the other happening. Gives us the ability to add custom screen cover effects in future.
- Quicksand now blocks light (see `getShadeBrightness`)
- Third-person camera can now move through Soft Quicksand blocks. This is important otherwise your camera gets stuck inside the block in third-person view. (see `getVisualShape` in `QuicksandBase`)
- Fixed collision box calculation (offset) for Soft Quicksand (see `FlowingQuicksandBase` and `SlowdownMixin`)
- ~~Don't render block faces between solid quicksand blocks (see `skipRendering` in `QuicksandBase`)~~
- Enabled occlusion for `tidal_mud`

## Known Issues

- It's possible to stand next to a quicksand block and partially clip the first-person camera inside it if you've got a high FOV setting.
- ~~You can suffocate in a block without the screen being covered.~~ **fixed**

## ~~Internal face culling~~

Turns out I just needed to add the tidal mud block to the `quicksand_ao_override.json` file and that was it.

~~Figured I'd put screenshots for this since it's the weirdest one. We'd set `getVisualShape` to be `empty` to allow the camera to pass through the blocks (important for third-person camera while submerged). However, this also was causing faces _between_ full blocks to be rendered. We can remove these faces again by using the same check that glass does. This'll be important for performance later down the line, especially as we start generating worlds with more quicksand blocks.~~

Demo setup

<img width="1920" height="1080" alt="2026-02-10_17 55 00" src="https://github.com/user-attachments/assets/19a94157-5906-43a5-95c6-b22e2ca9b332" />

Third person camera placed inside block, rendering internal faces

<img width="1920" height="1080" alt="2026-02-10_17 57 10" src="https://github.com/user-attachments/assets/347ebf13-d16d-4cc9-aba9-f080de019226" />

Third person camera placed inside block, internal faces removed

<img width="1920" height="1080" alt="2026-02-10_17 55 22" src="https://github.com/user-attachments/assets/f50f5e02-d608-4d3b-b295-98f09b576313" />
