### PR TITLE
Upload build output to releases

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -1,21 +1,14 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
-
 name: Java CI with Gradle
 
 on:
   push:
     branches: [ "1.20.1-develop" ]
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
 
     steps:
     - uses: actions/checkout@v4
@@ -25,27 +18,19 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
 
-    # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
-    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      uses: gradle/actions/setup-gradle@v4
     - name: Setup perms
       run: chmod +x gradlew
     - name: Build with Gradle Wrapper
       run: ./gradlew build
-    - name: Upload jars
-      uses: actions/upload-artifact@v4.6.2
-      with:
-       path: build/libs
-    
 
-    # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
-    # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.
-    #
-    # - name: Setup Gradle
-    #   uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
-    #   with:
-    #     gradle-version: '8.9'
-    #
-    # - name: Build with Gradle 8.9
-    #   run: gradle build
+    - name: Create and publish GitHub Release from branch
+      uses: ncipollo/release-action@v1
+      with:
+        tag: "v1.20.1-${{ github.run_number }}"  # generated tag name
+        commit: ${{ github.sha }}                # point tag to the current commit
+        artifacts: "build/libs/*.jar"
+        name: "Automated release ${{ github.run_number }}"
+        body: "Might be unstable, this is an automatic build, the something-all.jar is used by developers, you probably want the second one"
+        prerelease: true

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -32,5 +32,5 @@ jobs:
         commit: ${{ github.sha }}                # point tag to the current commit
         artifacts: "build/libs/*.jar"
         name: "Automated release ${{ github.run_number }}"
-        body: "Might be unstable, this is an automatic build, the something-all.jar is used by developers, you probably want the second one"
+        body: "This is an automated build based on the latest push; it is highly unstable, and there WILL be bugs. We recommend you do not use this release for modpacks or survival playthroughs.\nThe file titled _____-all.jar is used by developers, use the other file."
         prerelease: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building Java projects with Gradle. The main improvements are focused on automating release creation and artifact publishing, as well as updating dependencies and permissions.

Release automation and artifact publishing:

* Added a step to automatically create and publish a prerelease on GitHub for each build, including uploading JAR artifacts from `build/libs/*.jar` using the `ncipollo/release-action`.

Workflow dependency and permissions updates:

* Updated the Gradle setup action to use the latest version (`v4`) instead of a specific commit hash.
* Changed workflow permissions from `contents: read` to `contents: write` to allow release creation.

Cleanup and simplification:

* Removed unused steps and comments related to artifact uploading and alternative Gradle setup instructions.
* Cleaned up introductory comments in `.github/workflows/Build.yml` for clarity.