### PR TITLE
Added surface option to quicksand pits

### DIFF
--- a/src/main/java/net/mokai/quicksandrehydrated/registry/ModConfiguredFeatures.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/registry/ModConfiguredFeatures.java
@@ -25,7 +25,9 @@ public class ModConfiguredFeatures {
                 QuicksandPitConfiguration.DEFAULT_MAX_DEPTH,
                 QuicksandPitConfiguration.DEFAULT_IRREGULARITY,
                 QuicksandPitConfiguration.DEFAULT_HAS_BORDER,
+                QuicksandPitConfiguration.DEFAULT_HAS_SURFACE,
                 java.util.Optional.ofNullable(QuicksandPitConfiguration.DEFAULT_BORDER_BLOCK),
+                java.util.Optional.ofNullable(QuicksandPitConfiguration.DEFAULT_SURFACE_BLOCK),
                 java.util.Optional.of(QuicksandPitConfiguration.DEFAULT_REPLACEABLE_BLOCKS),
                 QuicksandPitConfiguration.DEFAULT_MIN_HEIGHT,
                 QuicksandPitConfiguration.DEFAULT_MAX_HEIGHT

--- a/src/main/java/net/mokai/quicksandrehydrated/worldgen/feature/QuicksandPitConfiguration.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/worldgen/feature/QuicksandPitConfiguration.java
@@ -3,22 +3,20 @@ package net.mokai.quicksandrehydrated.worldgen.feature;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.feature.configurations.FeatureConfiguration;
+import net.minecraft.world.level.block.Block;
 import net.mokai.quicksandrehydrated.registry.QuicksandRegistry;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
-/**
- * Configuration for the QuicksandPit feature.
- * Allows customizing the block used for the pit and other parameters.
- */
 public class QuicksandPitConfiguration implements FeatureConfiguration {
     // Default values
     public static final Block DEFAULT_BLOCK = QuicksandRegistry.QUICKSAND.get();
+    public static final boolean DEFAULT_HAS_SURFACE = false;
+    public static final Block DEFAULT_SURFACE_BLOCK = null;
     public static final int DEFAULT_MIN_RADIUS = 4;
     public static final int DEFAULT_MAX_RADIUS = 8;
     public static final int DEFAULT_MIN_DEPTH = 2;
@@ -29,9 +27,9 @@ public class QuicksandPitConfiguration implements FeatureConfiguration {
     public static final int DEFAULT_MIN_HEIGHT = 62; // Default minimum height (sea level)
     public static final int DEFAULT_MAX_HEIGHT = 320; // Default maximum height
     public static final List<Block> DEFAULT_REPLACEABLE_BLOCKS = Arrays.asList(
-            Blocks.SAND, Blocks.SANDSTONE, Blocks.RED_SAND, Blocks.RED_SANDSTONE, 
+            Blocks.SAND, Blocks.SANDSTONE, Blocks.RED_SAND, Blocks.RED_SANDSTONE,
             Blocks.DIRT, Blocks.COARSE_DIRT, Blocks.ROOTED_DIRT, Blocks.GRASS_BLOCK,
-            Blocks.TERRACOTTA, Blocks.WHITE_TERRACOTTA, Blocks.ORANGE_TERRACOTTA, 
+            Blocks.TERRACOTTA, Blocks.WHITE_TERRACOTTA, Blocks.ORANGE_TERRACOTTA,
             Blocks.YELLOW_TERRACOTTA, Blocks.BROWN_TERRACOTTA, Blocks.RED_TERRACOTTA
     );
 
@@ -52,8 +50,12 @@ public class QuicksandPitConfiguration implements FeatureConfiguration {
                     Codec.FLOAT.fieldOf("irregularity").orElse(DEFAULT_IRREGULARITY).forGetter(config -> config.irregularity),
                     // Whether to generate a border around the pit
                     Codec.BOOL.fieldOf("has_border").orElse(DEFAULT_HAS_BORDER).forGetter(config -> config.hasBorder),
+                    // Whether to generate a surface to the pit
+                    Codec.BOOL.fieldOf("has_surface").orElse(DEFAULT_HAS_SURFACE).forGetter(config -> config.hasSurface),
                     // Block to use for the border (defaults to same as pit if not specified)
                     BuiltInRegistries.BLOCK.byNameCodec().optionalFieldOf("border_block").forGetter(config -> config.borderBlock != null ? java.util.Optional.of(config.borderBlock) : java.util.Optional.empty()),
+                    // Block to use for the surface (defaults to same as pit if not specified)
+                    BuiltInRegistries.BLOCK.byNameCodec().optionalFieldOf("surface_block").forGetter(config -> config.surfaceBlock != null ? java.util.Optional.of(config.surfaceBlock) : java.util.Optional.empty()),
                     // List of blocks that can be replaced by quicksand
                     BuiltInRegistries.BLOCK.byNameCodec().listOf().optionalFieldOf("replaceable_blocks").forGetter(config -> java.util.Optional.of(config.replaceableBlocks)),
                     // Minimum height for generation
@@ -62,6 +64,7 @@ public class QuicksandPitConfiguration implements FeatureConfiguration {
                     Codec.INT.fieldOf("max_height").orElse(DEFAULT_MAX_HEIGHT).forGetter(config -> config.maxHeight)
             ).apply(instance, QuicksandPitConfiguration::new));
 
+
     public final Block block;
     public final int minRadius;
     public final int maxRadius;
@@ -69,14 +72,27 @@ public class QuicksandPitConfiguration implements FeatureConfiguration {
     public final int maxDepth;
     public final float irregularity;
     public final boolean hasBorder;
+    public final boolean hasSurface;
     public final Block borderBlock;
+    public final Block surfaceBlock;
     public final List<Block> replaceableBlocks;
     public final int minHeight;
     public final int maxHeight;
 
-    public QuicksandPitConfiguration(Block block, int minRadius, int maxRadius, int minDepth, int maxDepth, 
-                                    float irregularity, boolean hasBorder, java.util.Optional<Block> borderBlock,
-                                    java.util.Optional<List<Block>> replaceableBlocks, int minHeight, int maxHeight) {
+    public QuicksandPitConfiguration(
+            Block block,
+            int minRadius,
+            int maxRadius,
+            int minDepth,
+            int maxDepth,
+            float irregularity,
+            boolean hasBorder,
+            boolean hasSurface,
+            java.util.Optional<Block> borderBlock,
+            java.util.Optional<Block> surfaceBlock,
+            java.util.Optional<List<Block>> replaceableBlocks,
+            int minHeight,
+            int maxHeight) {
         this.block = block;
         this.minRadius = minRadius;
         this.maxRadius = maxRadius;
@@ -84,7 +100,9 @@ public class QuicksandPitConfiguration implements FeatureConfiguration {
         this.maxDepth = maxDepth;
         this.irregularity = irregularity;
         this.hasBorder = hasBorder;
+        this.hasSurface = hasSurface;
         this.borderBlock = borderBlock.orElse(null);
+        this.surfaceBlock = surfaceBlock.orElse(null);
         this.replaceableBlocks = replaceableBlocks.orElse(DEFAULT_REPLACEABLE_BLOCKS);
         this.minHeight = minHeight;
         this.maxHeight = maxHeight;

--- a/src/main/java/net/mokai/quicksandrehydrated/worldgen/feature/QuicksandPitFeature.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/worldgen/feature/QuicksandPitFeature.java
@@ -1,6 +1,9 @@
 package net.mokai.quicksandrehydrated.worldgen.feature;
 
+import java.util.List;
+
 import com.mojang.serialization.Codec;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.RandomSource;
@@ -10,8 +13,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
-
-import java.util.List;
 
 /**
  * Feature that generates a quicksand pit with customizable block type and shape.
@@ -40,6 +41,16 @@ public class QuicksandPitFeature extends Feature<QuicksandPitConfiguration> {
         // Get the block to use for the pit from the configuration
         Block pitBlock = config.block;
         BlockState pitBlockState = pitBlock.defaultBlockState();
+
+        // Get the surface block, if it exists
+        Block surfaceBlock;
+        if (config.hasSurface) {
+            surfaceBlock = config.surfaceBlock;
+        }
+        else {
+            surfaceBlock = config.block;
+        }
+        BlockState surfaceBlockState = surfaceBlock.defaultBlockState();
 
         // Generate a quicksand pit with random size based on configuration
         // Use a wider range for more variable sizes
@@ -223,6 +234,8 @@ public class QuicksandPitFeature extends Feature<QuicksandPitConfiguration> {
                     // Get deep into this position
                     int localDepth = depthMap[mapX][mapZ];
                     
+                    int surfaceY = findSurfaceY(level, new BlockPos(worldX, 0, worldZ));
+
                     // Verify that the height of the ground at this location is exactly equal to pitLevel.
                     // This prevents the puddle from spreading over different height levels.
                     int localSurfaceY = findSurfaceY(level, new BlockPos(worldX, 0, worldZ));
@@ -231,8 +244,12 @@ public class QuicksandPitFeature extends Feature<QuicksandPitConfiguration> {
                         continue;
                     }
                     
+                    BlockPos surfacePos = new BlockPos(worldX, surfaceY, worldZ);
+
+                    level.setBlock(surfacePos, surfaceBlockState, 3);
+                    
                     // Now let's place all the quicksand blocks at once, from top to bottom.
-                    for (int depth = 0; depth < localDepth; depth++) {
+                    for (int depth = 1; depth < localDepth; depth++) {
                         int worldY = pitLevel - depth;
                         BlockPos pos = new BlockPos(worldX, worldY, worldZ);
                         


### PR DESCRIPTION
DEFAULT_HAS_SURFACE : Boolean that determines whether the surface is a different block.
DEFAULT_SURFACE_BLOCK : Nullable block. If above is set to false, this is ignored. 

Creates a surface blockstate. If the has_surface is true, it will get the surface_block in config. If false, it will instead just be set to the default block. 