### PR TITLE
remove Quicksand.java logging every tick

### DIFF
--- a/src/main/java/net/mokai/quicksandrehydrated/block/quicksands/Quicksand.java
+++ b/src/main/java/net/mokai/quicksandrehydrated/block/quicksands/Quicksand.java
@@ -127,16 +127,6 @@ public class Quicksand extends QuicksandBase {
         entityQuicksandVar entQS = (entityQuicksandVar) pEntity;
         double liquid = pState.getValue(LIQUEFACTION);
 
-        System.out.print("{ ");
-        QuicksandEffectManager qsEffects = entQS.getQuicksandEffectManager();
-        for (QuicksandEffect effect : qsEffects.effects) {
-            System.out.print(effect.getClass().getSimpleName());
-            System.out.print(", ");
-        }
-        System.out.println(" }");
-
-
-
         // randomly play sounds
         Random rand = new Random();
         if (rand.nextInt(20*8) < 1) { // every 6 seconds

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/has_structure/quicksand_pit.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/has_structure/quicksand_pit.json
@@ -2,7 +2,6 @@
   "replace": false,
   "values": [
     "minecraft:desert",
-    "minecraft:desert_hills",
     "minecraft:badlands",
     "minecraft:wooded_badlands",
     "minecraft:eroded_badlands",


### PR DESCRIPTION
Credits to cesium
also included is removing desert_hills from from quicksand pit worldgen because that was removed as a biome in 1.18